### PR TITLE
Fix: An error pops up during a WebGL build #5

### DIFF
--- a/Packages/localization/Scripts/LocalizeSettings.cs
+++ b/Packages/localization/Scripts/LocalizeSettings.cs
@@ -72,8 +72,10 @@ namespace Localization
 
 			if (settingsList.Length > 1)
 			{
+#if UNITY_EDITOR
 				Debug.LogError("Need only one localization settings. See. " + string.Join(", ",
 					settingsList.Select(p => UnityEditor.AssetDatabase.GetAssetPath(p))));
+#endif
 			}
 			return settingsList[0];
 		}


### PR DESCRIPTION
For fix issue #5 
I just added the #if UNITY_EDITOR directive to where the file path is accessed. It seems to me that at the development stage in Unity itself, this will be enough.